### PR TITLE
修改CBMS202308的线代错误结果

### DIFF
--- a/docs/kakomonn/tokyo_university/frontier_sciences/cbms_202308_8.md
+++ b/docs/kakomonn/tokyo_university/frontier_sciences/cbms_202308_8.md
@@ -136,12 +136,12 @@ $\det(\mathbf{P} - \lambda\mathbf{I}) = (1-p-\lambda)(1-q-\lambda) - pq = 0$
 Solving this, we get:
 $\lambda_1 = 1$ and $\lambda_2 = 1 - p - q$
 
-The eigenvector corresponding to $\lambda_1 = 1$ is $\mathbf{v}_1 = \begin{pmatrix} q \\ p \end{pmatrix}$
+The eigenvector corresponding to $\lambda_1 = 1$ is $\mathbf{v}_1 = \begin{pmatrix} 1 \\ 1 \end{pmatrix}$
 
 Now we can write $\mathbf{P} = \mathbf{S}\mathbf{\Lambda}\mathbf{S}^{-1}$, where:
 
 $$
-\mathbf{S} = \begin{pmatrix} q & p \\ p & -q \end{pmatrix}, \quad
+\mathbf{S} = \begin{pmatrix} 1 & p \\ 1 & -q \end{pmatrix}, \quad
 \mathbf{\Lambda} = \begin{pmatrix} 1 & 0 \\ 0 & 1-p-q \end{pmatrix}
 $$
 
@@ -149,18 +149,9 @@ Therefore,
 
 $$
 \mathbf{P}^n = \mathbf{S}\mathbf{\Lambda}^n\mathbf{S}^{-1} = 
-\frac{1}{p^2 + q^2}\begin{pmatrix} q & p \\ p & -q \end{pmatrix}
+\frac{-1}{p + q}\begin{pmatrix} 1 & p \\ 1 & -q \end{pmatrix}
 \begin{pmatrix} 1 & 0 \\ 0 & (1-p-q)^n \end{pmatrix}
-\begin{pmatrix} q & p \\ p & -q \end{pmatrix}
-$$
-
-After multiplication, we get:
-
-$$
-\mathbf{P}^n = \begin{pmatrix} 
-\frac{q^2 + p^2(1-p-q)^n}{p^2 + q^2} & \frac{pq - pq(1-p-q)^n}{p^2 + q^2} \\
-\frac{pq - pq(1-p-q)^n}{p^2 + q^2} & \frac{p^2 + q^2(1-p-q)^n}{p^2 + q^2}
-\end{pmatrix}
+\begin{pmatrix} -q & -p \\ -1 & 1 \end{pmatrix}
 $$
 
 ### 3. Limit of $\mathbf{P}^n$ as $n \to \infty$
@@ -169,8 +160,8 @@ As $n \to \infty$, $(1-p-q)^n \to 0$ since $|1-p-q| < 1$. Therefore,
 
 $$
 \lim_{n \to \infty} \mathbf{P}^n = \begin{pmatrix}
-\frac{q^2}{p^2+q^2} & \frac{pq}{p^2+q^2} \\
-\frac{pq}{p^2+q^2} & \frac{p^2}{p^2+q^2}
+\frac{q}{p+q} & \frac{p}{p+q} \\
+\frac{q}{p+q} & \frac{p}{p+q}
 \end{pmatrix}
 $$
 


### PR DESCRIPTION
原答案对于线代第2小题中对应特征值 lambda=1情况时的特征向量求解错误，导致第二题和第三题结果都是存在错误的。因此予以更正。

如有问题请联系。