### PR TITLE
Add basic i18n support and translate index page for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,5 @@ jobs:
       - run: pip install mkdocs-git-revision-date-localized-plugin
       - run: pip install mkdocs-git-authors-plugin
       - run: pip install mkdocs-img2fig-plugin
+      - run: pip install mkdocs-static-i18n
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
Add basic i18n support and translate index page for testing
Fix Github Actions ERROR   `-  Config value 'plugins': The "i18n" plugin is not installed`