### PR TITLE
feat(agent-session): 浏览器经服务端代理访问 agent，禁止直连计算平面

### DIFF
--- a/src/components/AgentTutorContent/index.jsx
+++ b/src/components/AgentTutorContent/index.jsx
@@ -1,18 +1,17 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   FaCheckCircle,
-  FaClipboard,
   FaExclamationTriangle,
   FaPlay,
   FaRedo,
   FaRobot,
   FaShieldAlt,
 } from 'react-icons/fa';
-import { getLanguageLocale, useCurrentLanguage } from '@site/src/context/LanguageContext';
+import { useCurrentLanguage } from '@site/src/context/LanguageContext';
 import { useSync } from '@site/src/hooks/useSync';
 import {
-  createAgentSession,
   loadAgentBridgeStatus,
+  startChat,
   updateAgentConsents,
 } from '@site/src/services/agentBridgeService';
 import styles from './styles.module.css';
@@ -50,6 +49,7 @@ const TEXT = {
     sessionId: 'Session ID',
     expiresAt: '过期时间',
     tokenPreview: 'Session token',
+    replyPreview: '回复',
     consentProgress: '学习进度',
     consentProgressDesc: '允许 agent 读取题目完成状态、复习状态和标签摘要。',
     consentNotes: '题目笔记',
@@ -89,6 +89,7 @@ const TEXT = {
     sessionId: 'Session ID',
     expiresAt: '有効期限',
     tokenPreview: 'Session token',
+    replyPreview: '応答',
     consentProgress: '学習進捗',
     consentProgressDesc: 'agent が問題の完了状態、復習状態、タグ概要を読めるようにします。',
     consentNotes: '問題ノート',
@@ -128,6 +129,7 @@ const TEXT = {
     sessionId: 'Session ID',
     expiresAt: 'Expires at',
     tokenPreview: 'Session token',
+    replyPreview: 'Reply',
     consentProgress: 'Study progress',
     consentProgressDesc: 'Allow the agent to read problem status, review status, and tag summaries.',
     consentNotes: 'Problem notes',
@@ -145,27 +147,6 @@ function formatNumber(value) {
 function formatLimit(used, limit, t) {
   const safeLimit = Number(limit || 0);
   return `${formatNumber(used)} / ${safeLimit > 0 ? formatNumber(safeLimit) : t.unlimited}`;
-}
-
-function formatDate(value, language) {
-  if (!value) return '-';
-  try {
-    return new Date(value).toLocaleString(getLanguageLocale(language), {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  } catch {
-    return '-';
-  }
-}
-
-function shortToken(token) {
-  if (!token) return '';
-  if (token.length <= 36) return token;
-  return `${token.slice(0, 18)}...${token.slice(-12)}`;
 }
 
 function StatItem({ label, value, sub }) {
@@ -205,7 +186,6 @@ export function AgentTutorContent({ embedded = false } = {}) {
   const [loading, setLoading] = useState(false);
   const [savingField, setSavingField] = useState('');
   const [creating, setCreating] = useState(false);
-  const [copied, setCopied] = useState(false);
 
   const consents = status?.consents || {};
   const usage = status?.usage || {};
@@ -279,32 +259,19 @@ export function AgentTutorContent({ embedded = false } = {}) {
     }
   };
 
+  // 经 agent-session 服务端代理发一条测试消息，验证端到端链路（浏览器不直连 amaterasu、不接触 token）。
   const handleCreateSession = async () => {
     setCreating(true);
-    setCopied(false);
     setMessage(null);
     try {
-      const data = await createAgentSession();
+      const data = await startChat({ prompt: 'ping' });
       setSession(data);
-      setStatus((current) => current ? {
-        ...current,
-        consents: data?.consents || current.consents,
-        entitlements: data?.entitlements || current.entitlements,
-        usage: data?.usage || current.usage,
-      } : current);
       setMessage({ type: 'success', text: t.sessionReady });
     } catch (error) {
       setMessage({ type: 'error', text: error?.message || t.sessionFailed });
     } finally {
       setCreating(false);
     }
-  };
-
-  const handleCopyToken = async () => {
-    if (!session?.sessionToken) return;
-    await navigator.clipboard.writeText(session.sessionToken);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1600);
   };
 
   if (!authReady || loading && !status) {
@@ -361,7 +328,7 @@ export function AgentTutorContent({ embedded = false } = {}) {
         <StatItem
           label={t.bridgeStatus}
           value={configured ? t.configured : t.notConfigured}
-          sub={status?.agentBaseUrl || '-'}
+          sub={status?.agentUserId || '-'}
         />
         <StatItem
           label={t.plan}
@@ -421,30 +388,12 @@ export function AgentTutorContent({ embedded = false } = {}) {
           {session ? (
             <dl className={styles.sessionDetails}>
               <div>
-                <dt>{t.agentEndpoint}</dt>
-                <dd>{session.agentBaseUrl || '-'}</dd>
-              </div>
-              <div>
-                <dt>{t.agentUserId}</dt>
-                <dd>{session.agentUserId || '-'}</dd>
-              </div>
-              <div>
                 <dt>{t.sessionId}</dt>
                 <dd>{session.sessionId || '-'}</dd>
               </div>
               <div>
-                <dt>{t.expiresAt}</dt>
-                <dd>{formatDate(session.expiresAt, language)}</dd>
-              </div>
-              <div>
-                <dt>{t.tokenPreview}</dt>
-                <dd className={styles.tokenLine}>
-                  <code>{shortToken(session.sessionToken)}</code>
-                  <button className={styles.iconButton} type="button" onClick={handleCopyToken} title={t.copyToken}>
-                    <FaClipboard />
-                    <span>{copied ? t.copied : t.copyToken}</span>
-                  </button>
-                </dd>
+                <dt>{t.replyPreview}</dt>
+                <dd>{session.reply || '-'}</dd>
               </div>
             </dl>
           ) : null}

--- a/src/services/agentBridgeService.js
+++ b/src/services/agentBridgeService.js
@@ -1,4 +1,4 @@
-import { getSupabaseClient } from './supabaseClient';
+import { getSupabaseClient, getSupabaseCredentials } from './supabaseClient';
 import { getVerifiedAccessToken } from './syncService';
 import { getEdgeFunctionErrorMessage } from './edgeFunctionErrors';
 
@@ -61,4 +61,62 @@ export function renameChat(sessionId, title) {
 
 export function deleteChat(sessionId) {
   return invokeAgentSession('POST', { action: 'chat_delete', sessionId });
+}
+
+function parseSseEvent(raw) {
+  let type = 'message';
+  let data = '';
+  for (const line of raw.split('\n')) {
+    if (line.startsWith('event:')) type = line.slice(6).trim();
+    else if (line.startsWith('data:')) data += line.slice(5).trim();
+  }
+  if (!data) return null;
+  try {
+    return { type, data: JSON.parse(data) };
+  } catch {
+    return { type, data: { text: data } };
+  }
+}
+
+// 流式对话：fetch 直打 agent-session（仍经服务端代理转发 amaterasu 的 SSE），逐字回调 onEvent({type, data})，返回 final reply。
+export async function streamChat({ sessionId, prompt, model, pics, signal } = {}, onEvent) {
+  const accessToken = await getVerifiedAccessToken();
+  if (!accessToken) throw new Error('Login session is missing or expired.');
+  const { url, anonKey } = getSupabaseCredentials();
+  if (!url || !anonKey) throw new Error('Supabase is not configured.');
+
+  const res = await fetch(`${url}/functions/v1/agent-session`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      apikey: anonKey,
+      'Content-Type': 'application/json',
+      Accept: 'text/event-stream',
+    },
+    body: JSON.stringify({ action: sessionId ? 'chat_continue' : 'chat_start', sessionId, prompt, model, pics }),
+    signal,
+  });
+  if (!res.ok || !res.body) {
+    throw new Error((await res.text().catch(() => '')) || `Agent stream failed (${res.status}).`);
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let final = null;
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let idx;
+    while ((idx = buffer.indexOf('\n\n')) >= 0) {
+      const event = parseSseEvent(buffer.slice(0, idx));
+      buffer = buffer.slice(idx + 2);
+      if (!event) continue;
+      if (event.type === 'error') throw new Error(event.data.detail || 'Agent turn failed.');
+      if (event.type === 'final') final = event.data;
+      onEvent?.(event);
+    }
+  }
+  return final;
 }

--- a/src/services/agentBridgeService.js
+++ b/src/services/agentBridgeService.js
@@ -38,8 +38,27 @@ export function updateAgentConsents(consents) {
   });
 }
 
-export function createAgentSession() {
-  return invokeAgentSession('POST', {
-    action: 'create_session',
-  });
+// 以下聊天接口全部经 agent-session 服务端代理转发到 amaterasu，浏览器永不直连计算平面。
+export function startChat({ prompt, model, title, description, pics } = {}) {
+  return invokeAgentSession('POST', { action: 'chat_start', prompt, model, title, description, pics });
+}
+
+export function continueChat({ sessionId, prompt, model, pics } = {}) {
+  return invokeAgentSession('POST', { action: 'chat_continue', sessionId, prompt, model, pics });
+}
+
+export function listChats({ search, cursor, limit } = {}) {
+  return invokeAgentSession('POST', { action: 'chat_list', search, cursor, limit });
+}
+
+export function getChatHistory(sessionId) {
+  return invokeAgentSession('POST', { action: 'chat_history', sessionId });
+}
+
+export function renameChat(sessionId, title) {
+  return invokeAgentSession('POST', { action: 'chat_rename', sessionId, title });
+}
+
+export function deleteChat(sessionId) {
+  return invokeAgentSession('POST', { action: 'chat_delete', sessionId });
 }

--- a/src/services/supabaseClient.js
+++ b/src/services/supabaseClient.js
@@ -25,11 +25,13 @@ export const initSiteConfig = (siteConfig) => {
   if (!_siteConfig) _siteConfig = siteConfig;
 };
 
-const getCredentials = () => {
+export const getSupabaseCredentials = () => {
   const url = _siteConfig?.customFields?.supabaseUrl || '';
   const anonKey = _siteConfig?.customFields?.supabaseAnonKey || '';
   return { url, anonKey };
 };
+
+const getCredentials = getSupabaseCredentials;
 
 /**
  * 判断 Supabase 是否已配置（构建时是否注入了有效凭据）

--- a/supabase/functions/agent-session/index.ts
+++ b/supabase/functions/agent-session/index.ts
@@ -239,7 +239,6 @@ async function getStatus(user: User) {
   const state = await loadState(user.id);
   return jsonResponse({
     configured: isAgentConfigured(),
-    agentBaseUrl: AGENT_BASE_URL || null,
     agentUserId: state.link.agent_user_id,
     consents: publicConsents(state.consents),
     entitlements: publicEntitlement(state.entitlement),
@@ -278,18 +277,20 @@ function buildScopes(consents: ConsentRow) {
   return scopes;
 }
 
-async function createSession(user: User) {
-  if (!isAgentConfigured()) {
-    return errorResponse(503, 'agent_not_configured', 'Agent bridge is not configured.');
+async function ensureActiveState(
+  user: User,
+): Promise<{ error: Response } | { state: Awaited<ReturnType<typeof loadState>> }> {
+  const state = await loadState(user.id);
+  if (!['active', 'trialing'].includes(state.entitlement.status)) {
+    return { error: errorResponse(403, 'ai_entitlement_inactive', 'AI tutor access is not active for this account.') };
   }
+  return { state };
+}
 
+// 签发一个短期 session token（ES256，aud=kai-agent，sub=agent_user_id），仅用于本服务端 → amaterasu 的内部调用，绝不下发给浏览器。
+async function mintSessionToken(state: Awaited<ReturnType<typeof loadState>>) {
   const supabase = getSupabase();
   if (!supabase) throw new Error('Supabase Edge Function is not configured.');
-  const state = await loadState(user.id);
-
-  if (!['active', 'trialing'].includes(state.entitlement.status)) {
-    return errorResponse(403, 'ai_entitlement_inactive', 'AI tutor access is not active for this account.');
-  }
 
   const now = Math.floor(Date.now() / 1000);
   const exp = now + SESSION_TTL_SECONDS;
@@ -298,14 +299,9 @@ async function createSession(user: User) {
 
   const { data, error } = await supabase
     .from('agent_sessions')
-    .insert({
-      agent_user_id: state.link.agent_user_id,
-      scopes,
-      expires_at: expiresAt,
-    })
+    .insert({ agent_user_id: state.link.agent_user_id, scopes, expires_at: expiresAt })
     .select('id,expires_at')
     .single();
-
   if (error) throw error;
 
   const payload = {
@@ -324,18 +320,68 @@ async function createSession(user: User) {
     iat: now,
     exp,
   };
+  return await signJwt(payload, getPrivateJwk());
+}
 
-  const sessionToken = await signJwt(payload, getPrivateJwk());
-  return jsonResponse({
-    agentBaseUrl: AGENT_BASE_URL,
-    agentUserId: state.link.agent_user_id,
-    sessionId: data.id,
-    sessionToken,
-    expiresAt: data.expires_at,
-    consents: publicConsents(state.consents),
-    entitlements: publicEntitlement(state.entitlement),
-    usage: state.usage,
+// 浏览器 → 本函数 → amaterasu 的服务端代理：amaterasu 只接受携带本服务签发 token 的服务间调用，用户拿不到直连凭据。
+type AgentCall = { method: string; path: string; payload?: unknown };
+
+function enc(value: unknown) {
+  return encodeURIComponent(String(value ?? ''));
+}
+
+function requireSessionId(body: Record<string, unknown>) {
+  const id = typeof body?.sessionId === 'string' ? body.sessionId.trim() : '';
+  if (!id) throw new Error('missing_session_id');
+  return id;
+}
+
+function buildQuery(body: Record<string, unknown>, keys: string[]) {
+  const params = new URLSearchParams();
+  for (const key of keys) {
+    const value = body?.[key];
+    if (value !== undefined && value !== null && value !== '') params.set(key, String(value));
+  }
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+const CHAT_ACTIONS: Record<string, (body: Record<string, unknown>) => AgentCall> = {
+  chat_start: (b) => ({
+    method: 'POST',
+    path: '/sessions',
+    payload: { prompt: b.prompt, model: b.model, title: b.title, description: b.description, pics: b.pics },
+  }),
+  chat_continue: (b) => ({
+    method: 'POST',
+    path: `/sessions/${enc(requireSessionId(b))}/messages`,
+    payload: { prompt: b.prompt, model: b.model, pics: b.pics },
+  }),
+  chat_list: (b) => ({ method: 'GET', path: `/sessions${buildQuery(b, ['search', 'cursor', 'limit'])}` }),
+  chat_history: (b) => ({ method: 'GET', path: `/sessions/${enc(requireSessionId(b))}` }),
+  chat_rename: (b) => ({ method: 'PATCH', path: `/sessions/${enc(requireSessionId(b))}`, payload: { title: b.title } }),
+  chat_delete: (b) => ({ method: 'DELETE', path: `/sessions/${enc(requireSessionId(b))}` }),
+};
+
+async function proxyChat(user: User, call: AgentCall) {
+  if (!isAgentConfigured()) {
+    return errorResponse(503, 'agent_not_configured', 'Agent bridge is not configured.');
+  }
+  const result = await ensureActiveState(user);
+  if ('error' in result) return result.error;
+
+  const sessionToken = await mintSessionToken(result.state);
+  const res = await fetch(`${AGENT_BASE_URL.replace(/\/+$/, '')}${call.path}`, {
+    method: call.method,
+    headers: {
+      Authorization: `Bearer ${sessionToken}`,
+      ...(call.payload !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: call.payload !== undefined ? JSON.stringify(call.payload) : undefined,
   });
+
+  const text = await res.text();
+  return jsonResponse(text ? JSON.parse(text) : {}, res.status);
 }
 
 serve(async (req) => {
@@ -358,11 +404,20 @@ serve(async (req) => {
 
     if (req.method === 'POST') {
       const body = await readJsonBody(req);
-      if (body?.action === 'update_consents') {
+      const action = typeof body?.action === 'string' ? body.action : '';
+      if (action === 'update_consents') {
         return withCors(req, await updateConsents(auth.user, body));
       }
-      if (body?.action === 'create_session') {
-        return withCors(req, await createSession(auth.user));
+      const chat = CHAT_ACTIONS[action];
+      if (chat) {
+        try {
+          return withCors(req, await proxyChat(auth.user, chat(body)));
+        } catch (err) {
+          if (err instanceof Error && err.message === 'missing_session_id') {
+            return withCors(req, errorResponse(400, 'missing_session_id', 'A session id is required.'));
+          }
+          throw err;
+        }
       }
       return withCors(req, errorResponse(400, 'unknown_action', 'Unknown agent session action.'));
     }

--- a/supabase/functions/agent-session/index.ts
+++ b/supabase/functions/agent-session/index.ts
@@ -363,7 +363,7 @@ const CHAT_ACTIONS: Record<string, (body: Record<string, unknown>) => AgentCall>
   chat_delete: (b) => ({ method: 'DELETE', path: `/sessions/${enc(requireSessionId(b))}` }),
 };
 
-async function proxyChat(user: User, call: AgentCall) {
+async function proxyChat(user: User, call: AgentCall, wantStream = false) {
   if (!isAgentConfigured()) {
     return errorResponse(503, 'agent_not_configured', 'Agent bridge is not configured.');
   }
@@ -376,9 +376,18 @@ async function proxyChat(user: User, call: AgentCall) {
     headers: {
       Authorization: `Bearer ${sessionToken}`,
       ...(call.payload !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      ...(wantStream ? { Accept: 'text/event-stream' } : {}),
     },
     body: call.payload !== undefined ? JSON.stringify(call.payload) : undefined,
   });
+
+  // 流式：把 agent 的 SSE 流原样透传给浏览器（Deno 边收边发，不缓冲）。
+  if (wantStream && res.body) {
+    return new Response(res.body, {
+      status: res.status,
+      headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+    });
+  }
 
   const text = await res.text();
   return jsonResponse(text ? JSON.parse(text) : {}, res.status);
@@ -411,7 +420,9 @@ serve(async (req) => {
       const chat = CHAT_ACTIONS[action];
       if (chat) {
         try {
-          return withCors(req, await proxyChat(auth.user, chat(body)));
+          const wantStream = (action === 'chat_start' || action === 'chat_continue')
+            && (req.headers.get('accept') || '').includes('text/event-stream');
+          return withCors(req, await proxyChat(auth.user, chat(body), wantStream));
         } catch (err) {
           if (err instanceof Error && err.message === 'missing_session_id') {
             return withCors(req, errorResponse(400, 'missing_session_id', 'A session id is required.'));


### PR DESCRIPTION
浏览器经 `agent-session` 服务端代理访问 agent 计算平面，禁止直连；代理支持 SSE 流式透传。

- 删 `create_session`（原直连凭据下发口），token 签发收口到内部，仅服务端调用 agent 时使用
- 新增代理 action：`chat_start/continue/list/history/rename/delete`，服务端注入 Bearer token 转发到 `AGENT_BASE_URL`
- `chat_start/continue` 带 `Accept: text/event-stream` 时透传 agent 的 SSE 流，逐字流出
- 前端：`createAgentSession` → `startChat/continueChat/...` + `streamChat`（流式）
- 鉴权与 reserve/commit 计费契约不变