### PR TITLE
東京大学 新領域創成科学研究科 メディカル情報生命専攻 2024年8月実施 問題7・問題10 追加、問題8 (2) 修正

### DIFF
--- a/docs/tokyo-university/frontier_sciences/cbms/2025/cbms_202408_10.md
+++ b/docs/tokyo-university/frontier_sciences/cbms/2025/cbms_202408_10.md
@@ -1,0 +1,209 @@
+---
+sidebar_label: 2024年8月実施 問題10
+tags:
+  - Tokyo-University
+  - Computer-Science.Algorithm-Design.Two-Pointers
+  - Computer-Science.Algorithm-Design.Counting-Sort
+  - Computer-Science.Algorithm-Design.Radix-Sort
+---
+
+# 東京大学 新領域創成科学研究科 メディカル情報生命専攻 2024年8月実施 問題10
+
+## **Author**
+[zephyr-zdz](https://zephyr-zdz.space/)
+
+## **Description**
+We have $m$ DNA sequences, and each sequence has the same length $n$. The sequences contain four types of base: a, c, g, t. We wish to find all pairs of sequences where the last $x$ bases of one are identical to the first $x$ bases of the other ($x < n$).
+
+$P$ is an array of size $m$, which holds one pointer to each sequence. It has already been sorted according to the lexicographic order of the sequences.
+
+$Q$ is an array of size $m$, which holds one pointer to each sequence. It has already been sorted according to the lexicographic order of the last $x$ bases of each sequence.
+
+(1) Write pseudocode for an algorithm that outputs all pairs of sequences where the last $x$ bases of one are identical to the first $x$ bases of the other. It should exclude self-matches where one sequence has the same first and last $x$ bases. The running time of the algorithm should be linearly proportional to: $m$ plus the output size.
+
+Your algorithm can use the following routines.
+
+**prefixSuffixCompare** compares the length-$x$ prefix of its first argument to the length-$x$ suffix of its second argument, for example:
+
+$$
+\mathrm{prefixSuffixCompare}(P[i], Q[j], x)
+$$
+
+It returns $-1$ if the prefix is lexicographically less than the suffix, $0$ if they are equal, and $+1$ if the prefix is greater. You can assume that this routine uses a constant amount of running time.
+
+**output** outputs a pair of sequences, for example:
+
+$$
+\mathrm{output}(P[i], Q[j])
+$$
+
+In these examples, $0 \le i < m$ and $0 \le j < m$.
+
+(2) Next, we wish to find all prefix-suffix matches of length $x + 1$. Write pseudocode of an algorithm that fills in an array $R$ of size $m$, so that it holds one pointer to each sequence, sorted according to the lexicographic order of the last $x + 1$ bases of each sequence. The running time of the algorithm should be linearly proportional to $m$.
+
+Your algorithm can use this notation: $Q[i][z]$ is the base at position $z$ in the sequence pointed to by $Q[i]$, where $0 \le z < n$.
+
+### 题目描述
+
+给定 $m$ 条长度均为 $n$ 的 DNA 序列，碱基取自 a, c, g, t 四种。希望找出所有满足「一条序列的后 $x$ 个碱基与另一条序列的前 $x$ 个碱基完全相同」的序列对（$x < n$）。
+
+已知两个大小为 $m$ 的指针数组：
+
+- $P$：每条序列一个指针，已按序列整体的字典序排好序。
+- $Q$：每条序列一个指针，已按每条序列末尾 $x$ 个碱基的字典序排好序。
+
+1. 写出输出所有上述序列对的算法伪代码。需排除「某条序列自身的前 $x$ 与后 $x$ 个碱基相同」而与自己配对的情形。算法运行时间须与 $m$ 加输出规模成线性关系。可使用两个子程序：`prefixSuffixCompare(P[i], Q[j], x)` 比较第一个参数长度为 $x$ 的前缀与第二个参数长度为 $x$ 的后缀，前缀较小返回 $-1$、相等返回 $0$、较大返回 $+1$，可假定其运行时间为常数；`output(P[i], Q[j])` 输出一个序列对。
+2. 接着希望求长度为 $x+1$ 的前后缀匹配。写出算法伪代码，把每条序列的指针填入大小为 $m$ 的数组 $R$，使 $R$ 按每条序列末尾 $x+1$ 个碱基的字典序排列，运行时间须与 $m$ 成线性关系。可使用记号 $Q[i][z]$ 表示 $Q[i]$ 所指序列中位置 $z$ 处的碱基（$0 \le z < n$）。
+
+## **Kai**
+**Overview**
+
+The key observation is that the two arrays handed to us are precisely the two sorted orders the problem needs: $P$ groups the sequences by their first $x$ bases, and $Q$ groups them by their last $x$ bases. Part (1) is therefore not a search problem but a **join** problem — the same equality key appears, already sorted, on both sides — so a single linear merge pass locates every pair of matching blocks, and the only remaining work is emitting their cross product, whose cost is charged to the output size. This is exactly what the required running time of "$m$ plus the output size" is hinting at: it rules out testing all $m^2$ pairs, and it also tells us the answer may be far larger than $m$, so the cross product must be written out directly rather than filtered afterwards. Part (2) extends the suffix key by one base while staying linear. Since the new key is "the base at position $n - x - 1$" followed by "the old key", and $Q$ is already sorted by the old key, one **stable** counting sort on that single new base upgrades the order — one pass of an LSD radix sort. Stability is the whole point: it is what makes re-sorting from scratch unnecessary, and it is what keeps the cost at $O(m)$ instead of $O(m \log m)$.
+
+关键在于：题目给出的两个数组恰好就是所需的两种有序性——$P$ 按前 $x$ 个碱基把序列分组，$Q$ 按后 $x$ 个碱基把序列分组。因此 (1) 不是查找问题，而是**连接（join）**问题：同一个相等键已经在两侧分别排好序，于是一趟线性归并即可找出所有相匹配的块对，剩下的工作只是输出它们的笛卡尔积，其代价计入输出规模。题目要求的运行时间「$m$ 加输出规模」正是这个提示：它排除了枚举全部 $m^2$ 对的做法，同时也说明答案规模可能远大于 $m$，所以必须直接输出笛卡尔积，而不是先枚举再过滤。(2) 要在保持线性的前提下把后缀键延长一个碱基。新键等于「位置 $n - x - 1$ 处的碱基」接上「旧键」，而 $Q$ 已按旧键有序，故只需对这一个新增碱基做一次**稳定的**计数排序即可完成升级——也就是 LSD 基数排序的一趟。稳定性是关键：正是它使得无需从头重排，也正是它把代价保持在 $O(m)$ 而非 $O(m \log m)$。
+
+### (1)
+**Idea**
+
+$P$ is sorted by the lexicographic order of the whole sequences, so sequences sharing the same first $x$ bases occupy a contiguous block of $P$. Likewise, $Q$ is sorted by the lexicographic order of the last $x$ bases, so sequences sharing the same last $x$ bases occupy a contiguous block of $Q$.
+
+Hence it suffices to perform a **merge join** between the key "first $x$ bases" on $P$ and the key "last $x$ bases" on $Q$: whenever the two keys agree, output the full cross product of the two blocks.
+
+**Pseudocode**
+
+```text
+i ← 0
+j ← 0
+while i < m and j < m:
+    r ← prefixSuffixCompare(P[i], Q[j], x)
+    if r = -1:                 // prefix of P[i] < suffix of Q[j]
+        i ← i + 1
+    else if r = +1:            // prefix of P[i] > suffix of Q[j]
+        j ← j + 1
+    else:                      // match: locate the ends of both blocks
+        i2 ← i
+        while i2 < m and prefixSuffixCompare(P[i2], Q[j], x) = 0:
+            i2 ← i2 + 1
+        j2 ← j
+        while j2 < m and prefixSuffixCompare(P[i], Q[j2], x) = 0:
+            j2 ← j2 + 1
+        for a ← i to i2 - 1:
+            for b ← j to j2 - 1:
+                if P[a] ≠ Q[b]:        // exclude a sequence paired with itself
+                    output(P[a], Q[b])
+        i ← i2
+        j ← j2
+```
+
+Here $\mathrm{output}(P[a], Q[b])$ denotes the pair in which the last $x$ bases of $Q[b]$ coincide with the first $x$ bases of $P[a]$. The test $P[a] \ne Q[b]$ compares pointers, i.e. it checks whether both entries refer to the same sequence.
+
+**Correctness**
+
+Let $A_s$ be the set of sequences whose first $x$ bases equal $s$, and $B_s$ the set of sequences whose last $x$ bases equal $s$. The answer is exactly
+
+$$
+\bigcup_{s} \left\{ (p, q) \mid p \in A_s,\ q \in B_s,\ p \ne q \right\}
+$$
+
+$A_s$ appears as a contiguous block of $P$ and $B_s$ as a contiguous block of $Q$, and both keys are non-decreasing along their arrays. The merge join advances the side holding the smaller key, so it enumerates every pair of blocks sharing a common key $s$, exactly once. For each such pair it scans the cross product and drops only the pairs of a sequence with itself, which matches the expression above.
+
+**Complexity**
+
+- Every comparison advances $i$ or $j$ by one, so the branches other than `else` are taken at most $2m$ times in total.
+- Locating the block ends costs $(i_2 - i) + (j_2 - j)$ per matching block pair. The blocks are disjoint intervals of $P$ and of $Q$, so this sums to at most $2m$ over all block pairs.
+- The double loop runs $ab$ times for a block pair of sizes $a$ and $b$. The only iterations that produce no output are those pairing a sequence with itself, of which there are at most $\min(a, b)$ per block pair and at most $m$ in total. So the double loop runs at most (output size) $+\ m$ times.
+
+Altogether the running time is $O(m + \text{output size})$, as required.
+
+**思路**
+
+$P$ 按序列整体的字典序排好序，因此前 $x$ 个碱基相同的序列在 $P$ 中占据一段连续区间（块）；同理 $Q$ 按末尾 $x$ 个碱基的字典序排好序，因此后 $x$ 个碱基相同的序列在 $Q$ 中也占据一段连续区间。
+
+于是只需对 $P$ 的「前 $x$ 碱基」这一键与 $Q$ 的「后 $x$ 碱基」这一键做**归并连接（merge join）**：两键相等时，输出两个块的完整笛卡尔积。
+
+上述伪代码中，$\mathrm{output}(P[a], Q[b])$ 表示「$Q[b]$ 的后 $x$ 个碱基与 $P[a]$ 的前 $x$ 个碱基相同」这一对；$P[a] \ne Q[b]$ 是指针比较，用于判断两项是否指向同一条序列。
+
+**正确性**
+
+设前 $x$ 碱基等于 $s$ 的序列集合为 $A_s$，后 $x$ 碱基等于 $s$ 的序列集合为 $B_s$，则答案恰为
+
+$$
+\bigcup_{s} \left\{ (p, q) \mid p \in A_s,\ q \in B_s,\ p \ne q \right\}
+$$
+
+$A_s$ 是 $P$ 的连续区间，$B_s$ 是 $Q$ 的连续区间，且两侧的键沿数组单调不减。归并连接总是推进键较小的一侧，因此不重不漏地枚举出所有共享同一键 $s$ 的区间对；对每个区间对遍历笛卡尔积，仅剔除同一序列自身配对的情形，与上式一致。
+
+**复杂度**
+
+- 每次比较都使 $i$ 或 $j$ 前进 $1$，故 `else` 以外的分支合计至多执行 $2m$ 次。
+- 定位块端点对每个匹配块对花费 $(i_2 - i) + (j_2 - j)$ 次；这些块分别是 $P$ 与 $Q$ 上互不相交的区间，故所有块对合计至多 $2m$ 次。
+- 对大小为 $a \times b$ 的块对，二重循环执行 $ab$ 次；其中不产生输出的只有同一序列自身配对的情形，每个块对至多 $\min(a, b)$ 个，全部块对合计至多 $m$ 个。故二重循环合计至多执行（输出规模）$+\ m$ 次。
+
+综上，总运行时间为 $O(m + \text{输出规模})$，满足题目要求。
+
+### (2)
+**Idea**
+
+The last $x+1$ bases decompose into "the base at position $z = n - x - 1$" followed by "the last $x$ bases". So the lexicographic order of the last $x+1$ bases is the lexicographic order of the key pair
+
+$$
+(\ Q[i][z],\ \text{last } x \text{ bases}\ )
+$$
+
+in which $Q[i][z]$ is the more significant key.
+
+$Q$ is already sorted by the less significant key (the last $x$ bases), so one **stable counting sort** on the base at position $z$ suffices — this is exactly one step of an LSD radix sort. The alphabet has only the four bases a, c, g, t (a constant), so the counting sort runs in $O(m)$ time. Note that $x < n$ guarantees $z = n - x - 1 \ge 0$.
+
+**Pseudocode**
+
+```text
+z ← n - x - 1                    // 0-indexed position of the (x+1)-th base from the end
+
+for each base β in {a, c, g, t}:      // initialize the counters
+    count[β] ← 0
+
+for i ← 0 to m - 1:                   // count the bases at position z
+    count[Q[i][z]] ← count[Q[i][z]] + 1
+
+total ← 0                             // prefix sums give each base its starting offset
+for β in (a, c, g, t):                // lexicographic order a < c < g < t
+    start[β] ← total
+    total ← total + count[β]
+
+for i ← 0 to m - 1:                   // scanning Q in its own order keeps this stable
+    β ← Q[i][z]
+    R[start[β]] ← Q[i]
+    start[β] ← start[β] + 1
+```
+
+**Correctness**
+
+Counting sort is stable: elements with equal keys keep their relative order from the input. The input $Q$ is ordered by the last $x$ bases, so entries sharing the same base at position $z$ retain that order inside $R$. The starting offsets are computed by prefix sums taken in the lexicographic order a, c, g, t, so entries are ordered by the base at position $z$. Therefore $R$ is sorted by $(Q[i][z], \text{last } x \text{ bases})$, i.e. by the lexicographic order of the last $x+1$ bases.
+
+**Complexity**
+
+Each loop performs $O(1)$ iterations (four bases) or $O(m)$ iterations, and each iteration takes constant time. The total running time is therefore $O(m)$, as required.
+
+Finally, running the algorithm of (1) on $P$ and this $R$ with $x+1$ in place of $x$ yields all prefix-suffix matches of length $x+1$.
+
+**思路**
+
+末尾 $x+1$ 个碱基可拆成「位置 $z = n - x - 1$ 处的碱基」加「末尾 $x$ 个碱基」。因此末尾 $x+1$ 碱基的字典序，等同于键对
+
+$$
+(\ Q[i][z],\ \text{末尾 } x \text{ 个碱基}\ )
+$$
+
+的字典序，其中 $Q[i][z]$ 是更高位的键。
+
+$Q$ 已按低位键（末尾 $x$ 碱基）排好序，故只需对位置 $z$ 的碱基做一次**稳定的计数排序（counting sort）**即可——这正是 LSD 基数排序的一步。字母表只有 a, c, g, t 四种（常数个），因此该计数排序为 $O(m)$。注意由 $x < n$ 可保证 $z = n - x - 1 \ge 0$。
+
+**正确性**
+
+计数排序是稳定排序：键相同的元素保持输入中的相对顺序。输入 $Q$ 按末尾 $x$ 碱基有序，故位置 $z$ 碱基相同的元素在 $R$ 中仍保持该顺序；而写入起始位置是按 a, c, g, t 的字典序做前缀和得到的，故元素按位置 $z$ 的碱基有序。于是 $R$ 按 $(Q[i][z], \text{末尾 } x \text{ 碱基})$ 的字典序排列，即按末尾 $x+1$ 碱基的字典序排列。
+
+**复杂度**
+
+各循环分别执行 $O(1)$ 次（四种碱基）或 $O(m)$ 次，每次迭代为常数时间，故总运行时间为 $O(m)$，满足题目要求。
+
+最后，把这样得到的 $R$ 与 $P$ 一起、以 $x+1$ 代替 $x$ 运行 (1) 的算法，即可求出所有长度为 $x+1$ 的前后缀匹配。

--- a/docs/tokyo-university/frontier_sciences/cbms/2025/cbms_202408_10.md
+++ b/docs/tokyo-university/frontier_sciences/cbms/2025/cbms_202408_10.md
@@ -60,7 +60,7 @@ Your algorithm can use this notation: $Q[i][z]$ is the base at position $z$ in t
 
 The key observation is that the two arrays handed to us are precisely the two sorted orders the problem needs: $P$ groups the sequences by their first $x$ bases, and $Q$ groups them by their last $x$ bases. Part (1) is therefore not a search problem but a **join** problem — the same equality key appears, already sorted, on both sides — so a single linear merge pass locates every pair of matching blocks, and the only remaining work is emitting their cross product, whose cost is charged to the output size. This is exactly what the required running time of "$m$ plus the output size" is hinting at: it rules out testing all $m^2$ pairs, and it also tells us the answer may be far larger than $m$, so the cross product must be written out directly rather than filtered afterwards. Part (2) extends the suffix key by one base while staying linear. Since the new key is "the base at position $n - x - 1$" followed by "the old key", and $Q$ is already sorted by the old key, one **stable** counting sort on that single new base upgrades the order — one pass of an LSD radix sort. Stability is the whole point: it is what makes re-sorting from scratch unnecessary, and it is what keeps the cost at $O(m)$ instead of $O(m \log m)$.
 
-关键在于：题目给出的两个数组恰好就是所需的两种有序性——$P$ 按前 $x$ 个碱基把序列分组，$Q$ 按后 $x$ 个碱基把序列分组。因此 (1) 不是查找问题，而是**连接（join）**问题：同一个相等键已经在两侧分别排好序，于是一趟线性归并即可找出所有相匹配的块对，剩下的工作只是输出它们的笛卡尔积，其代价计入输出规模。题目要求的运行时间「$m$ 加输出规模」正是这个提示：它排除了枚举全部 $m^2$ 对的做法，同时也说明答案规模可能远大于 $m$，所以必须直接输出笛卡尔积，而不是先枚举再过滤。(2) 要在保持线性的前提下把后缀键延长一个碱基。新键等于「位置 $n - x - 1$ 处的碱基」接上「旧键」，而 $Q$ 已按旧键有序，故只需对这一个新增碱基做一次**稳定的**计数排序即可完成升级——也就是 LSD 基数排序的一趟。稳定性是关键：正是它使得无需从头重排，也正是它把代价保持在 $O(m)$ 而非 $O(m \log m)$。
+关键在于：题目给出的两个数组恰好就是所需的两种有序性——$P$ 按前 $x$ 个碱基把序列分组，$Q$ 按后 $x$ 个碱基把序列分组。因此 (1) 不是查找问题，而是**连接（join）问题**：同一个相等键已经在两侧分别排好序，于是一趟线性归并即可找出所有相匹配的块对，剩下的工作只是输出它们的笛卡尔积，其代价计入输出规模。题目要求的运行时间「$m$ 加输出规模」正是这个提示：它排除了枚举全部 $m^2$ 对的做法，同时也说明答案规模可能远大于 $m$，所以必须直接输出笛卡尔积，而不是先枚举再过滤。(2) 要在保持线性的前提下把后缀键延长一个碱基。新键等于「位置 $n - x - 1$ 处的碱基」接上「旧键」，而 $Q$ 已按旧键有序，故只需对这一个新增碱基做一次**稳定的**计数排序即可完成升级——也就是 LSD 基数排序的一趟。稳定性是关键：正是它使得无需从头重排，也正是它把代价保持在 $O(m)$ 而非 $O(m \log m)$。
 
 ### (1)
 **Idea**
@@ -196,7 +196,7 @@ $$
 
 的字典序，其中 $Q[i][z]$ 是更高位的键。
 
-$Q$ 已按低位键（末尾 $x$ 碱基）排好序，故只需对位置 $z$ 的碱基做一次**稳定的计数排序（counting sort）**即可——这正是 LSD 基数排序的一步。字母表只有 a, c, g, t 四种（常数个），因此该计数排序为 $O(m)$。注意由 $x < n$ 可保证 $z = n - x - 1 \ge 0$。
+$Q$ 已按低位键（末尾 $x$ 碱基）排好序，故只需对位置 $z$ 的碱基做一次**稳定的计数排序**（counting sort）即可——这正是 LSD 基数排序的一步。字母表只有 a, c, g, t 四种（常数个），因此该计数排序为 $O(m)$。注意由 $x < n$ 可保证 $z = n - x - 1 \ge 0$。
 
 **正确性**
 

--- a/docs/tokyo-university/frontier_sciences/cbms/2025/cbms_202408_7.md
+++ b/docs/tokyo-university/frontier_sciences/cbms/2025/cbms_202408_7.md
@@ -1,0 +1,290 @@
+---
+sidebar_label: 2024年8月実施 問題7
+tags:
+  - Tokyo-University
+  - Computer-Science.Algorithm-Design.Asymptotic-Upper-and-Lower-Bound-Proofs
+  - Computer-Science.Algorithm-Design.Recurrence-Relation-Complexity
+  - Computer-Science.Algorithm-Design.Divide-and-Conquer
+---
+
+# 東京大学 新領域創成科学研究科 メディカル情報生命専攻 2024年8月実施 問題7
+
+## **Author**
+[zephyr-zdz](https://zephyr-zdz.space/)
+
+## **Description**
+Let $n$ be a positive integer. Let $f(n)$ and $g(n)$ denote functions that represent computation time for solving a problem of size $n$. To provide an asymptotic upper bound on $f(n)$, we define:
+
+$$
+O(g(n)) = \left\{ f(n) \;\middle|\; \begin{array}{l} \text{There exist positive constants } c_0 \text{ and } n_0 \text{ such that} \\ f(n) \le c_0 g(n) \text{ for all } n \ge n_0 \end{array} \right\}
+$$
+
+Let $c\ (\ge 1)$ be a constant number. Prove that the following statements are true:
+
+(1) If $f(n) = 2^n + n^2$, then $f(n) \in O(2^n)$.
+
+(2) If $f(n) = n^3 2^n$, then $f(n) \in O(2^{2n})$.
+
+(3) If $f(1) = c$ and $f(n) = 2f(n-1) + cn \ (n > 1)$, then $f(n) \in O(2^{2n})$.
+
+(4) If $f(1) = c$ and $f(n) = 2f(\lfloor n/2 \rfloor) + cn \ (n > 1)$, where $\lfloor x \rfloor$ denotes the largest integer that is equal to or smaller than real number $x$, then $f(n) \in O(n \log n)$.
+
+### 题目描述
+
+设 $n$ 为正整数，$f(n)$、$g(n)$ 表示求解规模为 $n$ 的问题所需的计算时间。为给出 $f(n)$ 的渐近上界，定义
+
+$$
+O(g(n)) = \left\{ f(n) \;\middle|\; \begin{array}{l} \text{存在正常数 } c_0, n_0, \text{ 使得} \\ \text{对一切 } n \ge n_0 \text{ 有 } f(n) \le c_0 g(n) \end{array} \right\}
+$$
+
+设 $c\ (\ge 1)$ 为常数，证明下列命题成立：
+
+1. 若 $f(n) = 2^n + n^2$，则 $f(n) \in O(2^n)$。
+2. 若 $f(n) = n^3 2^n$，则 $f(n) \in O(2^{2n})$。
+3. 若 $f(1) = c$ 且 $f(n) = 2f(n-1) + cn\ (n > 1)$，则 $f(n) \in O(2^{2n})$。
+4. 若 $f(1) = c$ 且 $f(n) = 2f(\lfloor n/2 \rfloor) + cn\ (n > 1)$，其中 $\lfloor x \rfloor$ 表示不超过实数 $x$ 的最大整数，则 $f(n) \in O(n \log n)$。
+
+各小问都要求按定义给出 $c_0$ 与 $n_0$（或等价的推导），而非仅指出量级。
+
+## **Kai**
+**Overview**
+
+All four parts ask for the same thing: exhibit explicit constants $c_0$ and $n_0$ witnessing the definition of $O(\cdot)$ given above, rather than merely naming the growth rate. Parts (1) and (2) reduce to a single polynomial-versus-exponential lemma — $n^2 \le 2^n$ for $n \ge 4$, and $n^3 \le 2^n$ for $n \ge 10$ — each proved by induction, after which the required bound is immediate. Parts (3) and (4) are recurrences. In (3) the argument decreases by one, so the recurrence can be solved exactly; the closed form turns out to be $\Theta(2^n)$, comfortably below the requested $2^{2n}$. In (4) the argument is halved, which is the classic divide-and-conquer recurrence of merge sort; the floor is handled by strong induction combined with the monotonicity of $t\,(1 + \log_2 t)$, which lets $\lfloor n/2 \rfloor$ be relaxed to $n/2$ without breaking the bound. Throughout, recall that $O$ states only an upper bound, so a loose but correct estimate is a complete answer.
+
+四个小问要求的其实是同一件事：按上面给出的 $O(\cdot)$ 定义，明确给出常数 $c_0$ 与 $n_0$，而不是仅仅指出增长量级。(1) 和 (2) 都归结为一个「多项式 vs 指数」的引理——$n \ge 4$ 时 $n^2 \le 2^n$，$n \ge 10$ 时 $n^3 \le 2^n$——各用归纳法证明后，所需上界立即得到。(3) 和 (4) 是递推式：(3) 中自变量每次减 $1$，可直接求出精确闭式解，其量级为 $\Theta(2^n)$，远低于题目要求的 $2^{2n}$；(4) 中自变量每次减半，即归并排序那类分治递推，取整符号用强归纳法配合 $t\,(1 + \log_2 t)$ 的单调性处理，从而可把 $\lfloor n/2 \rfloor$ 放大为 $n/2$ 而不破坏上界。始终要记得 $O$ 只声明上界，因此偏松但正确的估计就是完整答案。
+
+### (1)
+First we prove the lemma that $n^2 \le 2^n$ for $n \ge 4$, by mathematical induction.
+
+**Base case:** For $n = 4$ we have $n^2 = 16$ and $2^n = 16$, so $16 \le 16$ holds.
+
+**Inductive step:** Assume $n^2 \le 2^n$ for some $n \ge 4$. For $n \ge 3$,
+
+$$
+n^2 - (2n + 1) = (n-1)^2 - 2 \ge 2^2 - 2 = 2 > 0
+$$
+
+so $2n + 1 < n^2$. Hence
+
+$$
+(n+1)^2 = n^2 + 2n + 1 < 2n^2 \le 2 \cdot 2^n = 2^{n+1}
+$$
+
+which establishes the claim for $n+1$. Therefore $n^2 \le 2^n$ for all $n \ge 4$.
+
+By this lemma, for $n \ge 4$,
+
+$$
+f(n) = 2^n + n^2 \le 2^n + 2^n = 2 \cdot 2^n
+$$
+
+Taking $c_0 = 2$ and $n_0 = 4$ satisfies the definition, so $f(n) \in O(2^n)$.
+
+先用数学归纳法证明引理：当 $n \ge 4$ 时 $n^2 \le 2^n$。
+
+**基例：** $n = 4$ 时 $n^2 = 16$、$2^n = 16$，故 $16 \le 16$ 成立。
+
+**归纳步：** 设某个 $n \ge 4$ 满足 $n^2 \le 2^n$。当 $n \ge 3$ 时
+
+$$
+n^2 - (2n + 1) = (n-1)^2 - 2 \ge 2^2 - 2 = 2 > 0
+$$
+
+即 $2n + 1 < n^2$。于是
+
+$$
+(n+1)^2 = n^2 + 2n + 1 < 2n^2 \le 2 \cdot 2^n = 2^{n+1}
+$$
+
+对 $n+1$ 也成立。故对一切 $n \ge 4$ 有 $n^2 \le 2^n$。
+
+由该引理，当 $n \ge 4$ 时 $f(n) = 2^n + n^2 \le 2^n + 2^n = 2 \cdot 2^n$。取 $c_0 = 2$、$n_0 = 4$ 即满足定义，故 $f(n) \in O(2^n)$。
+
+### (2)
+We prove the lemma that $n^3 \le 2^n$ for $n \ge 10$, by mathematical induction.
+
+**Base case:** For $n = 10$, $n^3 = 1000 \le 1024 = 2^{10}$.
+
+**Inductive step:** Assume $n^3 \le 2^n$ for some $n \ge 10$. Since $n \ge 10$ implies $1 + \frac{1}{n} \le \frac{11}{10}$,
+
+$$
+(n+1)^3 = n^3 \left(1 + \frac{1}{n}\right)^3 \le n^3 \left(\frac{11}{10}\right)^3 = 1.331\, n^3 < 2 n^3 \le 2 \cdot 2^n = 2^{n+1}
+$$
+
+which establishes the claim for $n+1$. Therefore $n^3 \le 2^n$ for all $n \ge 10$.
+
+By this lemma, for $n \ge 10$,
+
+$$
+f(n) = n^3 2^n \le 2^n \cdot 2^n = 2^{2n}
+$$
+
+Taking $c_0 = 1$ and $n_0 = 10$ satisfies the definition, so $f(n) \in O(2^{2n})$.
+
+用数学归纳法证明引理：当 $n \ge 10$ 时 $n^3 \le 2^n$。
+
+**基例：** $n = 10$ 时 $n^3 = 1000 \le 1024 = 2^{10}$。
+
+**归纳步：** 设某个 $n \ge 10$ 满足 $n^3 \le 2^n$。由 $n \ge 10$ 得 $1 + \frac{1}{n} \le \frac{11}{10}$，故
+
+$$
+(n+1)^3 = n^3 \left(1 + \frac{1}{n}\right)^3 \le n^3 \left(\frac{11}{10}\right)^3 = 1.331\, n^3 < 2 n^3 \le 2 \cdot 2^n = 2^{n+1}
+$$
+
+对 $n+1$ 也成立。故对一切 $n \ge 10$ 有 $n^3 \le 2^n$。
+
+由该引理，当 $n \ge 10$ 时 $f(n) = n^3 2^n \le 2^n \cdot 2^n = 2^{2n}$。取 $c_0 = 1$、$n_0 = 10$ 即满足定义，故 $f(n) \in O(2^{2n})$。
+
+### (3)
+We first solve the recurrence in closed form. The claim is
+
+$$
+f(n) = c\left(2^{n+1} - n - 2\right) \qquad (n \ge 1)
+$$
+
+which we prove by mathematical induction.
+
+**Base case:** For $n = 1$, $c(2^2 - 1 - 2) = c(4 - 3) = c = f(1)$.
+
+**Inductive step:** Assume $f(n-1) = c(2^n - (n-1) - 2) = c(2^n - n - 1)$ for some $n - 1 \ge 1$. Then
+
+$$
+\begin{aligned}
+f(n) &= 2f(n-1) + cn \\
+&= 2c\left(2^n - n - 1\right) + cn \\
+&= c\left(2^{n+1} - 2n - 2 + n\right) \\
+&= c\left(2^{n+1} - n - 2\right)
+\end{aligned}
+$$
+
+so the claim holds for $n$.
+
+Since $n + 2 > 0$ for $n \ge 1$,
+
+$$
+f(n) = c\left(2^{n+1} - n - 2\right) < c \cdot 2^{n+1} = 2c \cdot 2^n \le 2c \cdot 2^{2n}
+$$
+
+where the last inequality uses $2^n \le 2^{2n}$ for $n \ge 0$. Taking $c_0 = 2c$ and $n_0 = 1$ satisfies the definition, so $f(n) \in O(2^{2n})$.
+
+Note that this $f(n)$ is in fact in $O(2^n)$; the bound $O(2^{2n})$ asked for here is a loose one.
+
+先求递推式的闭式解。断言
+
+$$
+f(n) = c\left(2^{n+1} - n - 2\right) \qquad (n \ge 1)
+$$
+
+用数学归纳法证明。
+
+**基例：** $n = 1$ 时 $c(2^2 - 1 - 2) = c(4 - 3) = c = f(1)$。
+
+**归纳步：** 设某个 $n - 1 \ge 1$ 满足 $f(n-1) = c(2^n - n - 1)$，则
+
+$$
+\begin{aligned}
+f(n) &= 2f(n-1) + cn \\
+&= 2c\left(2^n - n - 1\right) + cn \\
+&= c\left(2^{n+1} - 2n - 2 + n\right) \\
+&= c\left(2^{n+1} - n - 2\right)
+\end{aligned}
+$$
+
+对 $n$ 也成立。
+
+由于 $n \ge 1$ 时 $n + 2 > 0$，有
+
+$$
+f(n) = c\left(2^{n+1} - n - 2\right) < c \cdot 2^{n+1} = 2c \cdot 2^n \le 2c \cdot 2^{2n}
+$$
+
+最后一个不等号用到 $n \ge 0$ 时 $2^n \le 2^{2n}$。取 $c_0 = 2c$、$n_0 = 1$ 即满足定义，故 $f(n) \in O(2^{2n})$。
+
+注：该 $f(n)$ 实际上属于 $O(2^n)$，本题要求的 $O(2^{2n})$ 是一个较松的上界。
+
+### (4)
+Throughout, $\log$ denotes the base-$2$ logarithm $\log_2$ (a change of base only alters the value by a constant factor, which does not affect the claim $O(n \log n)$).
+
+Claim: for every $n \ge 1$,
+
+$$
+f(n) \le c\, n \left(1 + \log_2 n\right)
+$$
+
+We prove this by strong induction on $n$.
+
+**Base case:** For $n = 1$, $f(1) = c$ and the right-hand side is $c \cdot 1 \cdot (1 + 0) = c$, so the claim holds.
+
+**Inductive step:** Let $n \ge 2$ and assume the claim holds for all $k$ with $1 \le k < n$. Put $m = \lfloor n/2 \rfloor$. Since $n \ge 2$ we have $1 \le m \le n/2 < n$, so the induction hypothesis applies to $m$.
+
+Let $h(t) = t(1 + \log_2 t)$. For $t \ge 1$,
+
+$$
+h'(t) = 1 + \log_2 t + \frac{1}{\ln 2} > 0
+$$
+
+so $h$ is increasing. From $m \le n/2$ and $n/2 \ge 1$ we get $h(m) \le h(n/2)$. Therefore
+
+$$
+\begin{aligned}
+f(n) &= 2f(m) + cn \\
+&\le 2c\, h(m) + cn \\
+&\le 2c\, h(n/2) + cn \\
+&= 2c \cdot \frac{n}{2}\left(1 + \log_2 n - 1\right) + cn \\
+&= c\, n \log_2 n + cn \\
+&= c\, n \left(1 + \log_2 n\right)
+\end{aligned}
+$$
+
+so the claim holds for $n$.
+
+Moreover, for $n \ge 2$ we have $1 \le \log_2 n$, hence
+
+$$
+f(n) \le c\, n \left(1 + \log_2 n\right) \le c\, n \left(\log_2 n + \log_2 n\right) = 2c\, n \log_2 n
+$$
+
+Taking $c_0 = 2c$ and $n_0 = 2$ satisfies the definition, so $f(n) \in O(n \log n)$.
+
+以下 $\log$ 均指以 $2$ 为底的对数 $\log_2$（换底只相差常数倍，不影响 $O(n \log n)$ 这一结论）。
+
+断言：对一切 $n \ge 1$，
+
+$$
+f(n) \le c\, n \left(1 + \log_2 n\right)
+$$
+
+对 $n$ 作强归纳法。
+
+**基例：** $n = 1$ 时 $f(1) = c$，右端为 $c \cdot 1 \cdot (1 + 0) = c$，成立。
+
+**归纳步：** 设 $n \ge 2$，且断言对一切 $1 \le k < n$ 成立。令 $m = \lfloor n/2 \rfloor$。由 $n \ge 2$ 得 $1 \le m \le n/2 < n$，故归纳假设可用于 $m$。
+
+令 $h(t) = t(1 + \log_2 t)$，当 $t \ge 1$ 时
+
+$$
+h'(t) = 1 + \log_2 t + \frac{1}{\ln 2} > 0
+$$
+
+故 $h$ 单调递增。由 $m \le n/2$ 且 $n/2 \ge 1$ 得 $h(m) \le h(n/2)$。于是
+
+$$
+\begin{aligned}
+f(n) &= 2f(m) + cn \\
+&\le 2c\, h(m) + cn \\
+&\le 2c\, h(n/2) + cn \\
+&= 2c \cdot \frac{n}{2}\left(1 + \log_2 n - 1\right) + cn \\
+&= c\, n \log_2 n + cn \\
+&= c\, n \left(1 + \log_2 n\right)
+\end{aligned}
+$$
+
+对 $n$ 也成立。
+
+又当 $n \ge 2$ 时 $1 \le \log_2 n$，故
+
+$$
+f(n) \le c\, n \left(1 + \log_2 n\right) \le c\, n \left(\log_2 n + \log_2 n\right) = 2c\, n \log_2 n
+$$
+
+取 $c_0 = 2c$、$n_0 = 2$ 即满足定义，故 $f(n) \in O(n \log n)$。

--- a/docs/tokyo-university/frontier_sciences/cbms/2025/cbms_202408_8.md
+++ b/docs/tokyo-university/frontier_sciences/cbms/2025/cbms_202408_8.md
@@ -208,50 +208,60 @@ $$
 $$
 
 ### (2)
-$\hat{A} = \hat{U}\hat{\Sigma}\hat{V}^T$ および $\hat{A}^+ = \hat{V}\hat{\Sigma}^{-1}\hat{U}^T$ を左辺に代入して計算する。
+$A = U\Sigma V^T$ であり、$\hat{U}$、$\hat{V}$ はそれぞれ $U$、$V$ の最初の $r$ 列からなる行列である。まず $A\hat{V}$ と $\hat{U}^T A$ を計算する。
+
+$V^TV = I_n$ より $V^T\hat{V} = \begin{pmatrix} I_r \\ O \end{pmatrix} \in \mathbb{R}^{n \times r}$ であるから、
+
+$$
+A\hat{V} = U\Sigma V^T\hat{V} = U\Sigma \begin{pmatrix} I_r \\ O \end{pmatrix} = U \begin{pmatrix} \hat{\Sigma} \\ O \end{pmatrix} = \hat{U}\hat{\Sigma}
+$$
+
+同様に $U^TU = I_n$ より $\hat{U}^TU = \begin{pmatrix} I_r & O \end{pmatrix} \in \mathbb{R}^{r \times n}$ であるから、
+
+$$
+\hat{U}^TA = \hat{U}^TU\Sigma V^T = \begin{pmatrix} I_r & O \end{pmatrix}\Sigma V^T = \begin{pmatrix} \hat{\Sigma} & O \end{pmatrix} V^T = \hat{\Sigma}\hat{V}^T
+$$
+
+これらを用いると、
 
 $$
 \begin{aligned}
-\hat{A}\hat{A}^+\hat{A} &= (\hat{U}\hat{\Sigma}\hat{V}^T) (\hat{V}\hat{\Sigma}^{-1}\hat{U}^T) (\hat{U}\hat{\Sigma}\hat{V}^T) \\
-&= \hat{U}\hat{\Sigma} (\hat{V}^T\hat{V}) \hat{\Sigma}^{-1} (\hat{U}^T\hat{U}) \hat{\Sigma}\hat{V}^T
+A\hat{A}^+A &= A(\hat{V}\hat{\Sigma}^{-1}\hat{U}^T)A \\
+&= (A\hat{V})\hat{\Sigma}^{-1}(\hat{U}^TA) \\
+&= \hat{U}\hat{\Sigma}\hat{\Sigma}^{-1}\hat{\Sigma}\hat{V}^T \\
+&= \hat{U}\hat{\Sigma}\hat{V}^T = \hat{A}
 \end{aligned}
 $$
 
-$\hat{V}^T\hat{V} = I_r$ および $\hat{U}^T\hat{U} = I_r$ であるため、
-
-$$
-\begin{aligned}
-\hat{A}\hat{A}^+\hat{A} &= \hat{U}\hat{\Sigma} I_r \hat{\Sigma}^{-1} I_r \hat{\Sigma}\hat{V}^T \\
-&= \hat{U} (\hat{\Sigma}\hat{\Sigma}^{-1}\hat{\Sigma}) \hat{V}^T \\
-&= \hat{U}\hat{\Sigma}\hat{V}^T \\
-&= \hat{A}
-\end{aligned}
-$$
-
-以上より、$\hat{A}\hat{A}^+\hat{A} = \hat{A}$ が示された。
+以上より、$A\hat{A}^+A = \hat{A}$ が示された。
 
 English:
-Substitute $\hat{A} = \hat{U}\hat{\Sigma}\hat{V}^T$ and $\hat{A}^+ = \hat{V}\hat{\Sigma}^{-1}\hat{U}^T$ into the left side:
+We have $A = U\Sigma V^T$, where $\hat{U}$ and $\hat{V}$ consist of the first $r$ columns of $U$ and $V$ respectively. We first compute $A\hat{V}$ and $\hat{U}^T A$.
+
+Since $V^TV = I_n$, we have $V^T\hat{V} = \begin{pmatrix} I_r \\ O \end{pmatrix} \in \mathbb{R}^{n \times r}$, hence
+
+$$
+A\hat{V} = U\Sigma V^T\hat{V} = U\Sigma \begin{pmatrix} I_r \\ O \end{pmatrix} = U \begin{pmatrix} \hat{\Sigma} \\ O \end{pmatrix} = \hat{U}\hat{\Sigma}
+$$
+
+Similarly, $U^TU = I_n$ gives $\hat{U}^TU = \begin{pmatrix} I_r & O \end{pmatrix} \in \mathbb{R}^{r \times n}$, hence
+
+$$
+\hat{U}^TA = \hat{U}^TU\Sigma V^T = \begin{pmatrix} I_r & O \end{pmatrix}\Sigma V^T = \begin{pmatrix} \hat{\Sigma} & O \end{pmatrix} V^T = \hat{\Sigma}\hat{V}^T
+$$
+
+Using these,
 
 $$
 \begin{aligned}
-\hat{A}\hat{A}^+\hat{A} &= (\hat{U}\hat{\Sigma}\hat{V}^T) (\hat{V}\hat{\Sigma}^{-1}\hat{U}^T) (\hat{U}\hat{\Sigma}\hat{V}^T) \\
-&= \hat{U}\hat{\Sigma} (\hat{V}^T\hat{V}) \hat{\Sigma}^{-1} (\hat{U}^T\hat{U}) \hat{\Sigma}\hat{V}^T
+A\hat{A}^+A &= A(\hat{V}\hat{\Sigma}^{-1}\hat{U}^T)A \\
+&= (A\hat{V})\hat{\Sigma}^{-1}(\hat{U}^TA) \\
+&= \hat{U}\hat{\Sigma}\hat{\Sigma}^{-1}\hat{\Sigma}\hat{V}^T \\
+&= \hat{U}\hat{\Sigma}\hat{V}^T = \hat{A}
 \end{aligned}
 $$
 
-Since $\hat{V}^T\hat{V} = I_r$ and $\hat{U}^T\hat{U} = I_r$:
-
-$$
-\begin{aligned}
-\hat{A}\hat{A}^+\hat{A} &= \hat{U}\hat{\Sigma} I_r \hat{\Sigma}^{-1} I_r \hat{\Sigma}\hat{V}^T \\
-&= \hat{U} (\hat{\Sigma}\hat{\Sigma}^{-1}\hat{\Sigma}) \hat{V}^T \\
-&= \hat{U}\hat{\Sigma}\hat{V}^T \\
-&= \hat{A}
-\end{aligned}
-$$
-
-Thus, $\hat{A}\hat{A}^+\hat{A} = \hat{A}$ is proven.
+Thus, $A\hat{A}^+A = \hat{A}$ is proven.
 
 ### (3)
 $P = XX^T$ とおくと、$X^TX = I_r$ であるため $P$ は階数 $r$ の直交射影行列である。


### PR DESCRIPTION
本 PR 针对东京大学 新領域創成科学研究科 メディカル情報生命専攻 令和7(2025)年度（2024年8月6日实施）专门科目。

## 变更内容

| 提交 | 内容 |
|---|---|
| 問題7 | 新增（O 记号的证明：多项式 vs 指数引理、递推式闭式解、分治递推） |
| 問題10 | 新增（DNA 序列前后缀匹配：归并连接、稳定计数排序） |
| 問題8 (2) | 修正已有解答 |

## 关于問題8 (2) 的修正

题目要求证明 $A\hat{A}^+A = \hat{A}$，而原解答证明的是 $\hat{A}\hat{A}^+\hat{A} = \hat{A}$，即 $\hat{A}^+$ 是 $\hat{A}$ 的广义逆——这是一个正确但不同的命题。两侧为 $A$ 的形式才是本题的要点，因此改为经由 $A\hat{V} = \hat{U}\hat{\Sigma}$ 与 $\hat{U}^TA = \hat{\Sigma}\hat{V}^T$ 的证明。

(1)(3)(4)(5) 未作改动，并保留了该文件原有的「日文 + `English:`」书写格式。

## 关于新增的两题

- 题目描述转录自英语版试题册，并在 `### 题目描述` 中附中文说明。
- 解答按小问组织，每小问先英文、后紧跟中文翻译。
- 問題7 每小问都按定义明确给出 $c_0$ 与 $n_0$。
- 問題10 除伪代码外，还给出正确性论证与复杂度依据（(1) 为 $O(m + 输出规模)$，(2) 为 $O(m)$）。

## 已完成的检查

- `yarn content:validate`：通过
- `yarn review:format --files <本 PR 的两个新文件>`：0 错误、0 警告
- 标签已用 `scripts/tag-taxonomy.js` 校验，仅使用现有 taxonomy 内的标签
- 問題7 的各处估计与递推式、問題10 的两个算法均已数值验证（算法部分与暴力枚举对拍）